### PR TITLE
Don't enforce cmake version

### DIFF
--- a/expat/CMakeLists.txt
+++ b/expat/CMakeLists.txt
@@ -424,8 +424,10 @@ if(NOT WIN32)
     set_property(TARGET expat PROPERTY NO_SONAME ${NO_SONAME})
 
     if(APPLE)
+        if(0)
         if(NOT CMAKE_VERSION VERSION_GREATER_EQUAL 3.17)
             message(FATAL_ERROR "Expat requires CMake >=3.17 on platform \"APPLE\".")
+        endif()
         endif()
 
         # NOTE: This intends to talk CMake into compatiblity with GNU Libtool


### PR DESCRIPTION
Fixes DFHack/dfhack#2140

The more recent cmake version is required for building shared libraries, which we do not do. Therefore we'd rather ignore the version requirement than make all our users upgrade.